### PR TITLE
False negatives?

### DIFF
--- a/email_veracity_checker.gemspec
+++ b/email_veracity_checker.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{email_veracity_checker}
-  s.version = "0.0.2"
+  s.version = "0.0.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Kiran Chaudhari"]

--- a/lib/email_check.rb
+++ b/lib/email_check.rb
@@ -108,7 +108,7 @@ class EmailCheck < Net::SMTP
   def check_mail_addr(domain, to_addr, decoy_from = nil)
     raise IOError, 'closed session' unless @socket
     raise ArgumentError, 'mail destination not given' if to_addr.empty?
-    helo domain
+#   helo domain
     mailfrom decoy_from
     rcptto to_addr
   end

--- a/lib/email_check.rb
+++ b/lib/email_check.rb
@@ -22,7 +22,6 @@ class EmailCheck < Net::SMTP
         500 => :fail,         # Syntax error, command unrecognised
         501 => :invalid,      # Syntax error in parameters or arguments
         503 => :fail,         # Bad sequence of commands
-        550 => :fail,         # Unknown user
         521 => :invalid,      # <domain> does not accept mail [rfc1846]
         421 => :fail,         # <domain> Service not available, closing transmission channel
       }


### PR DESCRIPTION
I've noticed that an email address is marked invalid in case the authoritative SMTP server doesn't accept HELO after the first EHLO.

Example of a conversation for checking an existing email address instead marked invalid:

Connection opened: smtp.aliceposta.it:25
-> "220 smtp106.alice.it ESMTP Service ready\r\n"
<- "EHLO example.com\r\n"
-> "250-smtp106.alice.it\r\n"
-> "250-DSN\r\n"
-> "250-8BITMIME\r\n"
-> "250-PIPELINING\r\n"
-> "250-HELP\r\n"
-> "250-AUTH=LOGIN\r\n"
-> "250-AUTH LOGIN CRAM-MD5 DIGEST-MD5 PLAIN\r\n"
-> "250-DELIVERBY 300\r\n"
-> "250 SIZE 31457280\r\n"
<- "HELO example.com\r\n"
-> "503 wrong state for HELO command\r\n"

Doing the same thing, manually by telnet, using only HELO, permits to continue the conversation and brings me to a valid email address result.

Any idea to solve this problem?

Is possible to fallback into an "HELO only" conversation and retry if a 503 error is received?
